### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ election procedure for a special election. If this vote succeeds, the Kommittee 
 question is removed from his or her Kommittee office.
   16. **Deallocations.** Motions to revoke an allocation (deallocate) require the same margin to
 pass as the original motion. (Fall 2007)
+17. **The No Airing of Grievances Amendment** With the exception of staff reports, subkommittee reports, and announcements on the agenda at the commencement of Kommittee, no business shall be conducted without an associated motion.  (Spring 2015, [^9])
 
 ======
 
@@ -908,4 +909,6 @@ particular shops which they use. (Fall 1988, moved Fall 2004) !
 [^7]: "Blame Kolb Ettenger (Spring 2007) for this."
 
 [^8]: "Blame Joey Moro (Spring 2012) for everything else."
+
+[^9]: "Blame Sarah Longchamp (Spring 2015) for this."
 


### PR DESCRIPTION
This is designed to avoid taking Kommittee time to "discuss our feelings about things that have been said/have happened."  One instance of this is the "kitchen allocation/heads-up wording mobpile SNAFU" of last semester.  The only time other than that which I've seen Kommittee time taken to conduct this sort of airing of our feelings was the Great Bias Incident of Spring 2011, which went similarly well, and spawned a number of other amendments. (V. H. and V. I. in particular were created out of that incident.)  While people may very well need to discuss their feelings and air them, doing so at a public meeting, where everyone is required to remain in the room at risk of being considered absent (Parlimentary Rules 9), and when doing such does not meaningfully contribute to the allocation of funds and resources for which Kommittee exists, is inappropriate.  As it stands, however, we have no way to prevent this, because without a motion, the question cannot be called.
